### PR TITLE
Mark header variables as extern

### DIFF
--- a/src/chess/zobrist.c
+++ b/src/chess/zobrist.c
@@ -76,3 +76,10 @@ void key_init()
     key_qsc[WHITE] = key_piece_positions[KINGS][WHITE][E1] ^ key_piece_positions[KINGS][WHITE][C1] ^ key_piece_positions[ROOKS][WHITE][D1] ^ key_piece_positions[ROOKS][WHITE][A1];
     key_qsc[BLACK] = key_piece_positions[KINGS][BLACK][E8] ^ key_piece_positions[KINGS][BLACK][C8] ^ key_piece_positions[ROOKS][BLACK][D8] ^ key_piece_positions[ROOKS][BLACK][A8];
 }
+
+uint64_t key_piece_positions[6][2][64];
+uint64_t key_turn;
+uint64_t key_castling[16];
+uint64_t key_ep_file[8];
+uint64_t key_ksc[2];
+uint64_t key_qsc[2];

--- a/src/chess/zobrist.h
+++ b/src/chess/zobrist.h
@@ -3,12 +3,12 @@
 
 #include "board.h"
 
-uint64_t key_piece_positions[6][2][64];
-uint64_t key_turn;
-uint64_t key_castling[16];
-uint64_t key_ep_file[8];
-uint64_t key_ksc[2];
-uint64_t key_qsc[2];
+extern uint64_t key_piece_positions[6][2][64];
+extern uint64_t key_turn;
+extern uint64_t key_castling[16];
+extern uint64_t key_ep_file[8];
+extern uint64_t key_ksc[2];
+extern uint64_t key_qsc[2];
 
 void key_init();
 uint64_t create_key_board(const s_board *board);

--- a/src/search/hashtable.c
+++ b/src/search/hashtable.c
@@ -111,3 +111,5 @@ int eval_from_tt(const int eval, const int ply)
     if(eval < -INF+MAX_DEPTH) {return eval + ply;}
     return eval;
 }
+
+s_hashtable hashtable;

--- a/src/search/hashtable.h
+++ b/src/search/hashtable.h
@@ -25,7 +25,7 @@ typedef struct
     int size_bytes;
 } s_hashtable;
 
-s_hashtable hashtable;
+extern s_hashtable hashtable;
 
 int hashtable_resize(s_hashtable *table, int size_megabytes);
 void hashtable_clear(s_hashtable *table);


### PR DESCRIPTION
To avoid using the gcc -fno-common flag.